### PR TITLE
Add work queue to subscribers

### DIFF
--- a/cpp/core/transport/include/basis/core/transport/inproc.h
+++ b/cpp/core/transport/include/basis/core/transport/inproc.h
@@ -145,13 +145,24 @@ private:
 };
 
 class InprocTransport {
+
+private:
+    template<typename T> 
+    InprocConnector<T>* GetConnector() {
+            // TODO: this static somewhat breaks the nice patterns around being explicit about how objects are initialized
+            // TODO: test with shared objects
+            static InprocConnector<T> connector;
+        return &connector;
+    }
 public:
   template <typename T> std::shared_ptr<InprocPublisher<T>> Advertise(std::string_view topic) {
-    // TODO: this static somewhat breaks the nice patterns around being explicit about how objects are initialized
-    static InprocConnector<T> connector;
-
-    return connector.Advertise(topic);
+    return GetConnector<T>()->Advertise(topic);
   }
+#if 0
+    template <typename T> std::shared_ptr<InprocSubscriber<T>> Subscribe(std::string_view topic, std::function<void(MessageEvent<T> message)> callback) {
+    return GetConnector<T>()->Subscribe(topic, callback);
+  }
+#endif
 };
 
 } // namespace basis::core::transport

--- a/cpp/core/transport/include/basis/core/transport/simple_mpsc.h
+++ b/cpp/core/transport/include/basis/core/transport/simple_mpsc.h
@@ -4,7 +4,7 @@
 #include <optional>
 #include <queue>
 
-namespace basis::plugins::transport {
+namespace basis::core::transport {
 
 /**
  * Simple thread safe Multi-producer Single Consumer Queue

--- a/cpp/core/transport/include/basis/core/transport/subscriber.h
+++ b/cpp/core/transport/include/basis/core/transport/subscriber.h
@@ -34,9 +34,10 @@ public:
 
   const std::string topic;
   const MessageTypeInfo type_info;
-  std::shared_ptr<InprocSubscriber<T_MSG>> inproc;
   // TODO: these are shared_ptrs - it could be a single unique_ptr if we were sure we never want to pool these
   std::vector<std::shared_ptr<TransportSubscriber>> transport_subscribers;
+  std::shared_ptr<InprocSubscriber<T_MSG>> inproc;
+
 };
 
 } // namespace transport

--- a/cpp/plugins/transport/tcp/include/basis/plugins/transport/tcp.h
+++ b/cpp/plugins/transport/tcp/include/basis/plugins/transport/tcp.h
@@ -121,11 +121,11 @@ public:
   };
 
   virtual std::shared_ptr<basis::core::transport::TransportSubscriber>
-  Subscribe(std::string_view topic, [[maybe_unused]] core::transport::MessageTypeInfo type_info) {
+  Subscribe(core::transport::OutputQueue* output_queue, std::string_view topic, [[maybe_unused]] core::transport::MessageTypeInfo type_info) {
     // TODO: specify thread pool name
-    // TODO: do we even need to store the thread pool manager or should it be passed in every time?
+    // TODO: pass in the thread pool every time
     std::shared_ptr<TcpSubscriber> subscriber =
-        *TcpSubscriber::Create(&epoll, thread_pool_manager->GetDefaultThreadPool().get());
+        *TcpSubscriber::Create(topic, &epoll, thread_pool_manager->GetDefaultThreadPool().get(), output_queue);
     {
       std::lock_guard lock(subscribers_mutex);
       subscribers.emplace(std::string(topic), subscriber);
@@ -165,6 +165,8 @@ private:
 
   std::mutex subscribers_mutex;
   std::unordered_multimap<std::string, std::weak_ptr<TcpSubscriber>> subscribers;
+
+// TODO: store list of known publishers?
 
   /// One epoll instance is shared across the whole TcpTransport - it's an implementation detail of tcp, even if we
   /// could share with other transports

--- a/cpp/plugins/transport/tcp/include/basis/plugins/transport/tcp_subscriber.h
+++ b/cpp/plugins/transport/tcp/include/basis/plugins/transport/tcp_subscriber.h
@@ -10,6 +10,7 @@
 #include <basis/core/transport/transport.h>
 #include "epoll.h"
 
+
 namespace basis::plugins::transport {
 
 struct AddressPortHash {
@@ -71,16 +72,19 @@ class TcpSubscriber : public core::transport::TransportSubscriber {
 public:
   // todo: error condition
   static std::expected<std::shared_ptr<TcpSubscriber>, core::networking::Socket::Error>
-  Create(Epoll *epoll, core::threading::ThreadPool *worker_pool,
+  Create(std::string_view topic_name, Epoll *epoll, core::threading::ThreadPool *worker_pool, core::transport::OutputQueue* output_queue,
          std::vector<std::pair<std::string_view, uint16_t>> addresses = {});
 
   // todo: error handling
   void Connect(std::string_view address, uint16_t port);
 
 protected:
-  TcpSubscriber(Epoll *epoll, core::threading::ThreadPool *worker_pool);
+  TcpSubscriber(std::string_view topic_name, Epoll *epoll, core::threading::ThreadPool *worker_pool, core::transport::OutputQueue* output_queue);
+
+  std::string topic_name;
   Epoll *epoll;
   core::threading::ThreadPool *worker_pool;
+  core::transport::OutputQueue *output_queue;
   std::unordered_map<std::pair<std::string, uint16_t>, TcpReceiver, AddressPortHash> receivers = {};
 };
 

--- a/cpp/plugins/transport/tcp/src/tcp_subscriber.cpp
+++ b/cpp/plugins/transport/tcp/src/tcp_subscriber.cpp
@@ -1,76 +1,74 @@
 #include <basis/plugins/transport/tcp_subscriber.h>
 
 namespace basis::plugins::transport {
-TcpSubscriber::TcpSubscriber(Epoll *epoll, core::threading::ThreadPool *worker_pool)
-    : epoll(epoll), worker_pool(worker_pool) {}
+TcpSubscriber::TcpSubscriber(std::string_view topic_name, Epoll *epoll, core::threading::ThreadPool *worker_pool,  core::transport::OutputQueue* output_queue)
+    : topic_name(topic_name), epoll(epoll), worker_pool(worker_pool), output_queue(output_queue) {}
 
 void TcpSubscriber::Connect(std::string_view address, uint16_t port) {
   std::pair<std::string, uint16_t> key(address, port);
-  if (receivers.count(key) != 0) {
-    return;
+  {
+    if (receivers.count(key) != 0) {
+        spdlog::warn("Already have address {}:{}", address, port);
+      return;
+    }
+
+    auto receiver = TcpReceiver(address, port);
+    if (!receiver.Connect()) {
+                spdlog::error("Unable to connect to {}:{}", address, port);
+
+      return;
+    }
+
+    // TODO now hook up to epoll!
+    receivers.emplace(key, std::move(receiver));
   }
 
-  auto receiver = TcpReceiver(address, port);
-  if (!receiver.Connect()) {
-    return;
-  }
-
-  //TODO now hook up to epoll!
-  //but first split this file up please
-  receivers.emplace(std::move(key), std::move(receiver));
-#if 0
-  auto callback = [&thread_pool, this, &output_queue](
-                      int fd, std::unique_lock<std::mutex> lock, std::string channel_name, TcpReceiver *receiver,
-                      std::shared_ptr<core::transport::IncompleteMessagePacket> incomplete) {
+  auto callback = [this](int fd, std::unique_lock<std::mutex> lock, TcpReceiver *receiver_ptr,
+                         std::shared_ptr<core::transport::IncompleteMessagePacket> incomplete) {
     spdlog::info("Queuing work for {}", fd);
 
-    /**
-     * This is called by epoll when new data is available on a socket. We immediately do nothing with it, and instead
-     * push the work off to the thread pool. This should be a very fast operation.
-     */
-    thread_pool.enqueue([fd, receiver, channel_name, this, &output_queue, incomplete, lock = std::move(lock)] {
+    worker_pool->enqueue([this, fd, incomplete = std::move(incomplete), receiver_ptr, lock = std::move(lock)] {
       // It's an error to actually call this with multiple threads.
       // TODO: add debug only checks for this
-      spdlog::debug("Running thread pool callback on {}", fd);
-      switch (receiver->ReceiveMessage(*incomplete)) {
+      switch (receiver_ptr->ReceiveMessage(*incomplete)) {
 
       case TcpReceiver::ReceiveStatus::DONE: {
-        spdlog::debug("TcpReceiver Got full message");
-        auto msg = incomplete->GetCompletedMessage();
-
-        std::pair<std::string, std::shared_ptr<core::transport::MessagePacket>> out(channel_name, std::move(msg));
-        output_queue.Emplace(std::move(out));
-
-        // TODO: peek
-        break;
+        std::pair<std::string, std::shared_ptr<core::transport::MessagePacket>> out(topic_name, incomplete->GetCompletedMessage());
+        output_queue->Emplace(std::move(out));
       }
       case TcpReceiver::ReceiveStatus::DOWNLOADING: {
+        // No work to be done
         break;
       }
       case TcpReceiver::ReceiveStatus::ERROR: {
+        // TODO
         spdlog::error("{}, {}: bytes {} - got error {} {}", fd, (void *)incomplete.get(),
                       incomplete->GetCurrentProgress(), errno, strerror(errno));
       }
       case TcpReceiver::ReceiveStatus::DISCONNECTED: {
-        spdlog::error("Disconnecting from channel {}", channel_name);
+
+        // TODO
+        spdlog::error("Disconnecting from topic {}", topic_name);
         return;
       }
       }
-      poller->ReactivateHandle(fd);
-      spdlog::info("Rearmed");
+      epoll->ReactivateHandle(fd);
     });
   };
-  #endif
+
+  TcpReceiver *receiver_ptr = &receivers.at(key);
+  epoll->AddFd(receiver_ptr->GetSocket().GetFd(),
+               std::bind(callback, std::placeholders::_1, std::placeholders::_2, receiver_ptr,
+                         std::make_shared<core::transport::IncompleteMessagePacket>()));
 }
 
 std::expected<std::shared_ptr<TcpSubscriber>, core::networking::Socket::Error>
-TcpSubscriber::Create(Epoll *epoll, core::threading::ThreadPool *worker_pool,
+TcpSubscriber::Create(std::string_view topic_name, Epoll *epoll, core::threading::ThreadPool *worker_pool, core::transport::OutputQueue* output_queue,
                       std::vector<std::pair<std::string_view, uint16_t>> addresses) {
-  auto subscriber = std::shared_ptr<TcpSubscriber>(new TcpSubscriber(epoll, worker_pool));
+  auto subscriber = std::shared_ptr<TcpSubscriber>(new TcpSubscriber(topic_name, epoll, worker_pool, output_queue));
   for (auto &[address, port] : addresses) {
     subscriber->Connect(address, port);
   }
   return subscriber;
 }
-
-}
+} // namespace basis::plugins::transport

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -5,8 +5,9 @@ This is an incomplete list.
 Initial hitlist (1-2 months?):
 - Inproc Transport
     - working
+    - subscriber needs hooked up to transport
 - TCP Transport
-    - semi working - will
+    - semi working
 - Protobuf Serializer
 - Coordinator
     - TCP Coordinator


### PR DESCRIPTION
Subscribers can now choose to either service callbacks immediately, or push to a work queue. Subscriber queueing to be implemented, after settings for subscribers are implemented.