### PR TITLE
Fix inproc subscription

### DIFF
--- a/cpp/core/transport/include/basis/core/transport/message_event.h
+++ b/cpp/core/transport/include/basis/core/transport/message_event.h
@@ -8,9 +8,9 @@ namespace basis::core::transport {
 struct TopicInfo {
   // TODO: a bunch of allocations here
   std::string topic;
-  std::string type;
-  std::string publisher_unit;
-  std::string publisher_host;
+  // std::string type;
+  // std::string publisher_unit;
+  // std::string publisher_host;
 };
 
 template <typename T_MSG> struct MessageEvent {

--- a/cpp/core/transport/include/basis/core/transport/subscriber.h
+++ b/cpp/core/transport/include/basis/core/transport/subscriber.h
@@ -82,8 +82,6 @@ public:
       : SubscriberBase(topic, std::move(type_info), std::move(transport_subscribers), inproc != nullptr),
         inproc(std::move(inproc)) {}
   
-
-
 protected:
   std::shared_ptr<InprocSubscriber<T_MSG>> inproc;
 };

--- a/cpp/core/transport/src/subscriber.cpp
+++ b/cpp/core/transport/src/subscriber.cpp
@@ -2,56 +2,62 @@
 
 #include <spdlog/spdlog.h>
 
+#include <unistd.h>
+
 namespace basis::core::transport {
-  void SubscriberBase::HandlePublisherInfo(const std::vector<PublisherInfo>& info) {
-    for(const PublisherInfo& publisher_info : info) {
-      if(publisher_info.topic != topic) {
-        spdlog::error("Skipping because no topic");
+void SubscriberBase::HandlePublisherInfo(const std::vector<PublisherInfo> &info) {
+  for (const PublisherInfo &publisher_info : info) {
+    if (publisher_info.topic != topic) {
+      spdlog::error("Skipping because no topic");
+      continue;
+    }
+    const __uint128_t &publisher_id = publisher_info.publisher_id;
+    auto it = publisher_id_to_transport_sub.find(publisher_id);
+
+    if (it != publisher_id_to_transport_sub.end()) {
+      if (it->second == nullptr) {
+        // Inproc is always valid
         continue;
       }
-      const __uint128_t& publisher_id = publisher_info.publisher_id;
-      auto it = publisher_id_to_transport_sub.find(publisher_id);
 
-      if(it != publisher_id_to_transport_sub.end()) {
-        if(it->second == nullptr) {
-          // Inproc is always valid
-          continue;
-        }
-
-      /// @todo BASIS-11: need to be able to handle disconnects
-      #if 0
+/// @todo BASIS-11: need to be able to handle disconnects
+#if 0
         if(it->second->IsConnectedToPublisher(publisher_id)) {
           continue;
         }
-      #else
-        continue;
-      #endif
-      }
+#else
+      continue;
+#endif
+    }
 
-      if(has_inproc && publisher_info.transport_info.contains("inproc")) {
+    // todo check if inproc pid is ours
+    if (has_inproc) {
+      auto it = publisher_info.transport_info.find("inproc");
+      if (it != publisher_info.transport_info.end() && it->second == std::to_string(getpid())) {
         // No need to do anything
         publisher_id_to_transport_sub.emplace(publisher_id, nullptr);
         continue;
       }
+    }
 
-      /// @todo BASIS-12: this will arbitrarily pick a transport once we add another type
-      for(auto& transport_subscriber : transport_subscribers) {
-        for(const auto& [pub_transport_name, pub_transport_endpoint] : publisher_info.transport_info) {
-          if(pub_transport_name == transport_subscriber->GetTransportName()) {
-            if(transport_subscriber->Connect("127.0.0.1", pub_transport_endpoint, publisher_id)) {
-              publisher_id_to_transport_sub.emplace(publisher_id, transport_subscriber.get());
-            }
+    /// @todo BASIS-12: this will arbitrarily pick a transport once we add another type
+    for (auto &transport_subscriber : transport_subscribers) {
+      for (const auto &[pub_transport_name, pub_transport_endpoint] : publisher_info.transport_info) {
+        if (pub_transport_name == transport_subscriber->GetTransportName()) {
+          if (transport_subscriber->Connect("127.0.0.1", pub_transport_endpoint, publisher_id)) {
+            publisher_id_to_transport_sub.emplace(publisher_id, transport_subscriber.get());
           }
         }
       }
     }
   }
-
-  size_t SubscriberBase::GetPublisherCount() {
-    size_t count = 0;
-    for(auto& ts : transport_subscribers) {
-      count += ts->GetPublisherCount();
-    }
-    return count;
-  }
 }
+
+size_t SubscriberBase::GetPublisherCount() {
+  size_t count = 0;
+  for (auto &ts : transport_subscribers) {
+    count += ts->GetPublisherCount();
+  }
+  return count;
+}
+} // namespace basis::core::transport

--- a/cpp/examples/src/basis_example.cpp
+++ b/cpp/examples/src/basis_example.cpp
@@ -27,6 +27,8 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char *argv[]) {
     spdlog::warn("No connection to the coordinator, running without coordinator");
   }
 
+  // todo why not output queue
+
   auto thread_pool_manager = std::make_shared<basis::core::transport::ThreadPoolManager>();
 
   basis::core::transport::TransportManager transport_manager(


### PR DESCRIPTION
To clarify - it was only working under unit tests, the needed code in TransportManager wasn't quite there yet (but close!)

I removed all the buffering code from inproc subscriber because it can be modeled the same way with the right callback