### PR TITLE
Fix debug build

### DIFF
--- a/python/unit/templates/handler.h.j2
+++ b/python/unit/templates/handler.h.j2
@@ -107,33 +107,7 @@ namespace unit::{{unit_name}}::{{handler_name}} {
         void SetupPubSub(
             basis::core::transport::TransportManager* transport_manager,
             basis::core::transport::OutputQueue* output_queue,
-            basis::core::threading::ThreadPool* thread_pool) {
-                // todo init sync
-        {% for topic_name, input in inputs.items() %}
-            {{input.cpp_topic_name}}_subscriber = transport_manager->Subscribe<{{input.cpp_message_type}}>("{{topic_name}}", 
-            [this](auto msg){
-                synchronizer->OnMessage<{{loop.index0}}>(msg);
-{% if 'rate' not in sync %}
-                synchronizer->ConsumeIfReady();
-{% endif %}
-            },
-            thread_pool, output_queue);
-        {% endfor %}
-        {% for topic_name, output in outputs.items() %}
-            {{output.cpp_topic_name}}_publisher = transport_manager->Advertise<{{output.cpp_message_type}}>("{{topic_name}}");
-        {% endfor %}
-        {% if 'rate' in sync %}
-        rate_subsciber = std::make_unique<basis::core::transport::RateSubscriber>(
-          basis::core::Duration::FromSecondsNanoseconds(0, int64_t(std::nano::den * {{sync.rate}})),
-          [this, output_queue](basis::core::MonotonicTime time) {
-            output_queue->Emplace([this, time]() {
-                OnRateSubscriber(time);
-            });
-          }
-          
-          );
-        {% endif %}
-        }
+            basis::core::threading::ThreadPool* thread_pool);
 
         void OnOutput(const Output& output) {
 {% for output_name, output in outputs.items() %}

--- a/python/unit/templates/unit_base.cpp.j2
+++ b/python/unit/templates/unit_base.cpp.j2
@@ -2,4 +2,39 @@
 
 namespace unit::{{unit_name}} {
 
+{# PubSub impls, to avoid weird linker errors and to speed up compilation time #}
+{% for handler_name, handler in handlers.items() %}
+namespace {{handler_name}} {
+    void PubSub::SetupPubSub(
+        basis::core::transport::TransportManager* transport_manager,
+        basis::core::transport::OutputQueue* output_queue,
+        basis::core::threading::ThreadPool* thread_pool) {
+            // todo init sync
+    {% for topic_name, input in handler.inputs.items() %}
+        {{input.cpp_topic_name}}_subscriber = transport_manager->Subscribe<{{input.cpp_message_type}}>("{{topic_name}}",
+        [this](auto msg){
+            synchronizer->OnMessage<{{loop.index0}}>(msg);
+{% if 'rate' not in handler.sync %}
+            synchronizer->ConsumeIfReady();
+{% endif %}
+        },
+        thread_pool, output_queue);
+    {% endfor %}
+    {% for topic_name, output in handler.outputs.items() %}
+        {{output.cpp_topic_name}}_publisher = transport_manager->Advertise<{{output.cpp_message_type}}>("{{topic_name}}");
+    {% endfor %}
+    {% if 'rate' in handler.sync %}
+    rate_subsciber = std::make_unique<basis::core::transport::RateSubscriber>(
+        basis::core::Duration::FromSecondsNanoseconds(0, int64_t(std::nano::den * {{handler.sync.rate}})),
+        [this, output_queue](basis::core::MonotonicTime time) {
+        output_queue->Emplace([this, time]() {
+            OnRateSubscriber(time);
+        });
+        }
+
+        );
+    {% endif %}
+    }
+}
+{% endfor %}
 }


### PR DESCRIPTION
Only under debug, I get messages like 
```
ld.lld: error: relocation refers to a discarded section: .rodata._ZTAXtlN4unit9test_unit16TestEqualOptions3$_3EEE
>>> defined in CMakeFiles/unit_test_unit.dir/generated/unit/test_unit/create_unit.cpp.o
>>> section group signature: _ZTAXtlN4unit9test_unit16TestEqualOptions3$_3EEE
>>> prevailing definition is in CMakeFiles/unit_test_unit.dir/src/test_unit.cpp.o
>>> referenced by field.h:100 (/basis/cpp/synchronizers/include/basis/synchronizers/field.h:100)
>>>               CMakeFiles/unit_test_unit.dir/generated/unit/test_unit/create_unit.cpp.o:(auto basis::synchronizers::FieldSync<basis::synchronizers::Equal, basis::synchronizers::Field<std::shared_ptr<sensor_msgs::Image_<std::allocator<void>> const>, unit::test_unit::TestEqualOptions::$_5{}>, basis::synchronizers::Field<std::shared_ptr<sensor_msgs::Image_<std::allocator<void>> const>, unit::test_unit::TestEqualOptions::$_4{}>, basis::synchronizers::Field<std::vector<std::shared_ptr<TestEmptyEvent const>, std::allocator<std::shared_ptr<TestEmptyEvent const>>>, nullptr>, basis::synchronizers::Field<std::vector<std::shared_ptr<TestEmptyEvent const>, std::allocator<std::shared_ptr<TestEmptyEvent const>>>, nullptr>, basis::synchronizers::Field<std::shared_ptr<sensor_msgs::Image_<std::allocator<void>> const>, unit::test_unit::TestEqualOptions::$_3{}>, basis::synchronizers::Field<std::shared_ptr<sensor_msgs::Image_<std::allocator<void>> const>, nullptr>>::GetFieldData<unit::test_unit::TestEqualOptions::$_3{}, sensor_msgs::Image_<std::allocator<void>> const*>(sensor_msgs::Image_<std::allocator<void>> const*) const)
>>> referenced by field.h:100 (/basis/cpp/synchronizers/include/basis/synchronizers/field.h:100)
>>>               CMakeFiles/unit_test_unit.dir/generated/unit/test_unit/create_unit.cpp.o:(auto basis::synchronizers::FieldSync<basis::synchronizers::Equal, basis::synchronizers::Field<std::shared_ptr<sensor_msgs::Image_<std::allocator<void>> const>, unit::test_unit::TestEqualOptions::$_5{}>, basis::synchronizers::Field<std::shared_ptr<sensor_msgs::Image_<std::allocator<void>> const>, unit::test_unit::TestEqualOptions::$_4{}>, basis::synchronizers::Field<std::vector<std::shared_ptr<TestEmptyEvent const>, std::allocator<std::shared_ptr<TestEmptyEvent const>>>, nullptr>, basis::synchronizers::Field<std::vector<std::shared_ptr<TestEmptyEvent const>, std::allocator<std::shared_ptr<TestEmptyEvent const>>>, nullptr>, basis::synchronizers::Field<std::shared_ptr<sensor_msgs::Image_<std::allocator<void>> const>, unit::test_unit::TestEqualOptions::$_3{}>, basis::synchronizers::Field<std::shared_ptr<sensor_msgs::Image_<std::allocator<void>> const>, nullptr>>::GetFieldData<unit::test_unit::TestEqualOptions::$_3{}, sensor_msgs::Image_<std::allocator<void>> const*>(sensor_msgs::Image_<std::allocator<void>> const*) const)
```

I tracked it down to this commit: https://github.com/basis-robotics/basis/pull/31/commits/30edd4326e88fb5670c25a6072747d0328987b40#diff-0dad748fec6c918ef2a3517d714be035704534eb8ef44b72c5422d693fa1e21d which triggers it by including the main include file for a unit into two different compilation units. This should be perfectly legal, but something is funky. There's a good chance this is a compiler bug. Further digging traces it specifically to the calls to `synchronizer->OnMessage<0>(msg);` inside the lambda inside `SetupPubSub`. It's possible some combination of template nesting and the field accesses triggers this. Rather than debug what's wrong with clang, I've bypassed the issue by moving the implementation of `SetupPubSub` into one cpp file. The same work should be done for other complex generated functions, if nothing else to speed up compilation time.