### PR TITLE
Fix autogenerated constructor

### DIFF
--- a/python/unit/templates/unit.h.j2
+++ b/python/unit/templates/unit.h.j2
@@ -12,7 +12,7 @@
 class {{unit_name}} : public unit::{{unit_name}}::Base {
 public:
   {{unit_name}}(const Args& args, const std::optional<std::string_view>& name_override = {}) 
-  : unit::{{unit_name}}::Base(name_override)
+  : unit::{{unit_name}}::Base(args, name_override)
   {}
 
 {% for handler_name in handlers %}


### PR DESCRIPTION
We went back and fixed any instances of units missing the `args` argument, but neglected to fix the new unit flow.